### PR TITLE
Fix help text for -listen cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To run the service, execute the binary:
 $ ./cieps-server -help
 Usage of ./cieps-server:
   -listen string
-    	Path to the server key file corresponding to the given certificate file (default ":443")
+    	TCP listen address in host:port format (default ":443")
   -server-cert string
     	Path to the server certificate file (default "server.crt")
   -server-key string

--- a/cli/cieps-server/main.go
+++ b/cli/cieps-server/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	serverCertFlag := flag.String("server-cert", "server.crt", "Path to the server certificate file")
 	serverKeyFlag := flag.String("server-key", "server.key", "Path to the server key file corresponding to the given certificate file")
-	listenAddrFlag := flag.String("listen", ":443", "Path to the server key file corresponding to the given certificate file")
+	listenAddrFlag := flag.String("listen", ":443", "TCP listen address in host:port format")
 	flag.Parse()
 
 	mux := http.NewServeMux()

--- a/internal/business/policy.go
+++ b/internal/business/policy.go
@@ -19,9 +19,11 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 )
 
-var shouldGenerateCA sync.Once
-var caCertificate *x509.Certificate
-var caKey crypto.Signer
+var (
+	shouldGenerateCA sync.Once
+	caCertificate    *x509.Certificate
+	caKey            crypto.Signer
+)
 
 func Evaluate(req *certutil.CIEPSRequest) (*certutil.CIEPSResponse, error) {
 	shouldGenerateCA.Do(generateSelfSignedRoot)


### PR DESCRIPTION
Reported by @brianshumate, thanks! 

The help text in the README and cli were incorrect. Also ran a gofumpt which cleaned up the var declarations.